### PR TITLE
Make production and pre-production not template

### DIFF
--- a/pre-production/configMap.yaml
+++ b/pre-production/configMap.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: the-map
-  labels:
-    region:  '{{ default "west" .Region }}'
 data:
   altGreeting: "Good Morning!"
   enableRisky: "false"

--- a/pre-production/deployment.yaml
+++ b/pre-production/deployment.yaml
@@ -6,11 +6,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      deployment: hello-{{ .Version }}
+      deployment: hello
   template:
     metadata:
       labels:
-        deployment: hello-{{ .Version }}
+        deployment: hello
     spec:
       containers:
       - name: the-container

--- a/pre-production/kustomization.yaml
+++ b/pre-production/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
 labels:
 - includeSelectors: true
   pairs:
-    app: hello-{{ .Version }}
+    app: hello

--- a/pre-production/service.yaml
+++ b/pre-production/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: the-service
 spec:
   selector:
-    deployment: hello-{{ .Version }}
+    deployment: hello
   type: LoadBalancer
   ports:
   - protocol: TCP

--- a/production/helloWorld/configMap.yaml
+++ b/production/helloWorld/configMap.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: the-map
-  labels:
-    region:  '{{ default "west" .Region }}'
 data:
   altGreeting: "Good Morning!"
   enableRisky: "false"

--- a/production/helloWorld/deployment.yaml
+++ b/production/helloWorld/deployment.yaml
@@ -6,11 +6,11 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      deployment: hello-{{ .Version }}
+      deployment: hello
   template:
     metadata:
       labels:
-        deployment: hello-{{ .Version }}
+        deployment: hello
     spec:
       containers:
       - name: the-container

--- a/production/helloWorld/kustomization.yaml
+++ b/production/helloWorld/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
 labels:
 - includeSelectors: true
   pairs:
-    app: hello-{{ .Version }}
+    app: hello

--- a/production/helloWorld/service.yaml
+++ b/production/helloWorld/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: the-service
 spec:
   selector:
-    deployment: hello-{{ .Version }}
+    deployment: hello
   type: LoadBalancer
   ports:
   - protocol: TCP


### PR DESCRIPTION
The goals of those paths is to show how KustomizationRef.Path can be expressed as a template